### PR TITLE
JCN quick add includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `package.include` property support for functions
 
 ## [1.4.1] - 2020-02-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Used to implement Lambda Functions (with no events)
 | handler | string | The function handler | **Required** | |
 | description | string | The function description | | |
 | timeout | number | The function timeout | | |
+| package.include | array[string] | The List of paths of files to include | | |
 
 #### Example
 

--- a/lib/plugins/core/function.js
+++ b/lib/plugins/core/function.js
@@ -19,7 +19,7 @@ module.exports = ({ functions, ...serviceConfig }, {
 		functionConfiguration.timeout = timeout;
 
 	if(options.package && options.package.include)
-		functionConfiguration.package = { include: options.package.include }
+		functionConfiguration.package = { include: options.package.include };
 
 	return {
 		...serviceConfig,

--- a/lib/plugins/core/function.js
+++ b/lib/plugins/core/function.js
@@ -4,7 +4,8 @@ module.exports = ({ functions, ...serviceConfig }, {
 	functionName,
 	handler,
 	description,
-	timeout
+	timeout,
+	...options
 }) => {
 
 	const functionConfiguration = {
@@ -16,6 +17,9 @@ module.exports = ({ functions, ...serviceConfig }, {
 
 	if(timeout)
 		functionConfiguration.timeout = timeout;
+
+	if(options.package && options.package.include)
+		functionConfiguration.package = { include: options.package.include }
 
 	return {
 		...serviceConfig,

--- a/tests/unit/plugins/core/function.js
+++ b/tests/unit/plugins/core/function.js
@@ -30,7 +30,8 @@ describe('Core plugins', () => {
 				functionName: 'MyFunction',
 				handler: 'path/to/handler.export',
 				description: 'My super description',
-				timeout: 6
+				timeout: 6,
+				package: { include: ['path/to/includ/file.js'] }
 			});
 
 			assert.deepStrictEqual(lambdaFunctionResult, {
@@ -38,7 +39,8 @@ describe('Core plugins', () => {
 					MyFunction: {
 						handler: 'path/to/handler.export',
 						description: 'My super description',
-						timeout: 6
+						timeout: 6,
+						package: { include: ['path/to/includ/file.js'] }
 					}
 				}]
 			});


### PR DESCRIPTION
## LINK AL TICKET
-
## DESCRIPCIÓN DEL REQUERIMIENTO
Las funciones no tienen la posibilidad de incluir archivos individualmente. Hay que agregar `package.include` como opción.

## DESCRIPCIÓN DE LA SOLUCIÓN
Se agregó el campo opcional `package.include`