### PR TITLE
add url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Used to implement Lambda Functions
 | memorySize | number | The function memorySize in MB _(since 1.10.0)_ | | |
 | reservedConcurrency | number | Reserved concurrency limit for the function. By default, AWS uses account concurrency limit _(since 1.11.0)_ | | |
 | package.include | array[string] | The List of paths of files to include | | |
+| url | boolean | Set as `true` to create a Lambda URL resource | | false |
 | rawProperties | object | Raw properties to be setup in the function configuration object | | |
 
 #### Example
@@ -190,6 +191,7 @@ module.exports = helper({
 					}
 				}
 			],
+			url: true,
 			rawProperties: {
 				rawProperties: 1
 			}

--- a/lib/plugins/core/function.js
+++ b/lib/plugins/core/function.js
@@ -9,11 +9,13 @@ module.exports = ({ functions, ...serviceConfig }, {
 	events,
 	package: pkg,
 	reservedConcurrency,
+	url,
 	rawProperties
 }) => {
 
 	const functionConfiguration = {
 		...rawProperties,
+		...url && { url },
 		handler
 	};
 

--- a/tests/unit/plugins/core/function.js
+++ b/tests/unit/plugins/core/function.js
@@ -44,7 +44,8 @@ describe('Core plugins', () => {
 						}
 					}
 				],
-				package: { include: ['path/to/include/file.js'] }
+				package: { include: ['path/to/include/file.js'] },
+				url: true
 			});
 
 			assert.deepStrictEqual(lambdaFunctionResult, {
@@ -66,7 +67,8 @@ describe('Core plugins', () => {
 								}
 							}
 						],
-						package: { include: ['path/to/include/file.js'] }
+						package: { include: ['path/to/include/file.js'] },
+						url: true
 					}
 				}]
 			});


### PR DESCRIPTION
Link al ticket

[Historia](https://janiscommerce.atlassian.net/browse/JC-268)
[Subtarea](https://janiscommerce.atlassian.net/browse/JC-272)

## Descripción del requerimiento

    Sumar soporte para la prop url

## Descripción de la solución

Se modifico el plugin core `function` para sumar, en caso de existir, la propiedad `url`

## Changelog
```
### Added
- ***Plugin*** to allow to create resources related with function urls
```